### PR TITLE
Set Last-Modified header

### DIFF
--- a/imagefit/models.py
+++ b/imagefit/models.py
@@ -5,6 +5,7 @@ from PIL import Image as PilImage
 import mimetypes
 import StringIO
 import re
+import os
 
 
 class Image(object):
@@ -25,6 +26,10 @@ class Image(object):
     @property
     def mimetype(self):
         return mimetypes.guess_type(self.path)[0]
+
+    @property
+    def modified(self):
+        return os.path.getmtime(self.path)
 
     @property
     def is_cached(self):


### PR DESCRIPTION
Pull request for https://github.com/vinyll/django-imagefit/issues/2 - this takes care of the headers, but for it to actually work, the user needs to enable `django.middleware.http.ConditionalGetMiddleware` as per https://docs.djangoproject.com/en/dev/ref/middleware/#module-django.middleware.http - might want to add that to the README
