### PR TITLE
Fixes for Django 1.8 / Python 2.7:

### DIFF
--- a/imagefit/conf.py
+++ b/imagefit/conf.py
@@ -29,10 +29,11 @@ class ImagefitConf(AppConf):
     IMAGEFIT_CACHE_ENABLED = True
     IMAGEFIT_CACHE_BACKEND_NAME = 'imagefit'
 
-    settings.CACHES[IMAGEFIT_CACHE_BACKEND_NAME] = {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': os.path.join(tempfile.gettempdir(), 'django_imagefit')
-    }
+    # On Django1.8, this overwrites all CACHES?
+    #settings.CACHES[IMAGEFIT_CACHE_BACKEND_NAME] = {
+    #    'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+    #    'LOCATION': os.path.join(tempfile.gettempdir(), 'django_imagefit')
+    #}
 
     #: ConditionalGetMiddleware is required for browser caching
     if not 'django.middleware.http.ConditionalGetMiddleware' in settings.MIDDLEWARE_CLASSES:

--- a/imagefit/views.py
+++ b/imagefit/views.py
@@ -41,7 +41,7 @@ def resize(request, path_name, format, url):
     statobj = os.stat(image.path)
     if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
                               statobj[stat.ST_MTIME], statobj[stat.ST_SIZE]):
-        return HttpResponseNotModified(mimetype=image.mimetype)
+        return HttpResponseNotModified() #mimetype=image.mimetype)
 
     if settings.IMAGEFIT_CACHE_ENABLED:
         image.cache = cache


### PR DESCRIPTION
- CACHES default overwrites settings.py.
- HttpResponseNotModified does not accept mimetime parameter.