### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ before uploading it
 
 #### Download
 
-Via pip ![latest version](https://pypip.in/v/django-imagefit/badge.png)
+Via pip ![latest version](https://img.shields.io/pypi/v/django-imagefit.svg)
 
 ```bash
 pip install django-imagefit


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-imagefit))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-imagefit`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.