### PR TITLE
Compatibility with Django 4 upward

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Contributors:
     Martin Bachwerk <https://github.com/arski>
     Sinan Islekdemir <https://github.com/sinanislekdemir>
     Michael Marx <https://github.com/rezemika>
+    Oluwafemi Ebenezer <https://github.com/bencipher>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It preserves the original image file.
 It is compatible with various sources of images such as django-filebrowser's
 FileBrowseField, user uploaded images, static images, …
 
-Works on Python 3.x and Python 2.6 or more; Django 1.4 > 2.0.
+Works on Python 3.x and Python 2.6 or more; Django 1.4 > 2.0. Compatible with Django 4.0
 
 
 #### Benefits

--- a/imagefit/urls.py
+++ b/imagefit/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 from . import views
 
 
 urlpatterns = [
-    url(
+    re_path(
         r'^(?P<path_name>[\w_-]*)/(?P<format>[,\w-]+)/(?P<url>.*)/?$',
         views.resize,
         name="imagefit_resize"),

--- a/imagefit/urls.py
+++ b/imagefit/urls.py
@@ -1,9 +1,20 @@
-from django.urls import re_path
 from . import views
 
+# EAFP compliance with version 4.0
+try:
+    from django.conf.urls import url
+except ImportError as e:
+    from django.urls import re_path
+    from django.utils import version
+
+    # in case of any other error
+    if int(version.get_version().split('.')[0]) >= 4:
+        url = re_path
+    else:
+        raise ImportError(str(e))
 
 urlpatterns = [
-    re_path(
+    url(
         r'^(?P<path_name>[\w_-]*)/(?P<format>[,\w-]+)/(?P<url>.*)/?$',
         views.resize,
         name="imagefit_resize"),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-imagefit',
-    version='0.6.2',
+    version='0.7.0',
     description='Render an optimized version of your original image on display. Ability to resize and crop.',
     long_description=open('README.md').read(),
     author='Vincent Agnano',


### PR DESCRIPTION
There is a path bug that crashes the app. because the URL method was deprecated in django v4